### PR TITLE
Replace depricated laravel helper

### DIFF
--- a/src/NovaTextCard.php
+++ b/src/NovaTextCard.php
@@ -2,6 +2,7 @@
 
 namespace Ericlagarda\NovaTextCard;
 
+use Illuminate\Support\Str;
 use Laravel\Nova\Card;
 
 class TextCard extends Card
@@ -132,7 +133,7 @@ class TextCard extends Card
     public function jsonSerialize()
     {
         return array_merge([
-            'name'  => str_random(16),
+            'name'  => Str::random(16),
             'width' => $this->width,
         ], parent::jsonSerialize());
     }


### PR DESCRIPTION
the `str_random`-helper was removed in laravel 6.0